### PR TITLE
Include META.json file in releases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Data::Currency
 
+0.05002 
+    - Added [MetaJSON] to dist.ini so releases include a META.json file
+
 0.05001 Sun Jul 14 15:00:00 2013
     - Corrected POD
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_holder = Christopher H. Laco, Mariano Wahlmann
 copyright_year   = 2013
 
 [@Basic]
+[MetaJSON]
 [PkgVersion]
 [PodVersion]
 [PodWeaver]

--- a/lib/Data/Currency.pm
+++ b/lib/Data/Currency.pm
@@ -1,5 +1,6 @@
 ## no critic (RequireUseStrict)
 package Data::Currency;
+
 ## use critic
 use strict;
 use warnings;


### PR DESCRIPTION
Hi,

The main purpose of this PR is to ensure that future releases have a META.json file. That file has better fidelity of dependency information compared to META.yml.

Also added a blank line after the package statement, which Dist::Zilla now wants.

Cheers,
Neil